### PR TITLE
install_dir won't work, because the params class is parsed before the init class

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,7 +28,6 @@ class graphite::params {
   $carbon_dl_loc                   = "${build_dir}/carbon-${::graphite::params::carbonVersion}.tar.gz"
 
   $nginxconf_dir                   = '/etc/nginx/sites-available'
-  $install_dir                      = $graphite::install_dir
   $user                            = 'www-data'
   $group                           = 'www-data'
   $carbon_metric_interval          = 60


### PR DESCRIPTION
This variable cannot be set correctly, but its presence was breaking strict_variables.
